### PR TITLE
Improve compatibility with NodeJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "./node_modules/mocha/bin/mocha --recursive"
   },
   "dependencies": {
+    "detect-node": "^2.0.4",
     "superagent": "1.7.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test": "./node_modules/mocha/bin/mocha --recursive"
   },
   "dependencies": {
-    "detect-node": "^2.0.4",
     "superagent": "1.7.1"
   },
   "devDependencies": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -157,7 +157,7 @@
    */
   exports.prototype.isFileParam = function(param) {
     // fs.ReadStream in Node.js (but not in runtime like browserify)
-    if (typeof window === 'undefined' &&
+    if (Object.prototype.toString.call(global.process) === '[object process]' &&
         typeof require === 'function' &&
         require('fs') &&
         param instanceof require('fs').ReadStream) {

--- a/src/api/DefaultApi.js
+++ b/src/api/DefaultApi.js
@@ -324,7 +324,7 @@
       var authNames = ['Token'];
       var contentTypes = [];
       var accepts = ['image/png', 'image/jpeg', 'applicant/pdf'];
-      var returnType = File;
+      var returnType = (typeof File !== 'undefined') ? File : [];
 
       return this.apiClient.callApi(
         '/applicants/{applicant_id}/documents/{document_id}/download', 'GET',
@@ -370,7 +370,7 @@
       var authNames = ['Token'];
       var contentTypes = [];
       var accepts = ['application/json'];
-      var returnType = File;
+      var returnType = (typeof File !== 'undefined') ? File : [];
 
       return this.apiClient.callApi(
         '/live_photos/{live_photo_id}/download', 'GET',


### PR DESCRIPTION
There are several common reasons why `window` might not be undefined in a NodeJS environment. 

The detection is based on the solution used by [detect-node](https://www.npmjs.com/package/detect-node), which should be a far more reliable test. 

Also `downloadFile` and `downloadLivePhoto` fail when called from Node JS because `File` is not defined. This PR defaults the `returnType` to `[]` for these if `File` is `undefined` so it can return a `Buffer` in NodeJS. 